### PR TITLE
fix for `Argument of type "type[Command]" cannot be assigned to parameter "cls" of type "C@command" in function "command"`

### DIFF
--- a/twitchio/ext/commands/core.py
+++ b/twitchio/ext/commands/core.py
@@ -636,7 +636,7 @@ G = TypeVar("G", bound="Group")
 
 
 def command(
-    *, name: str = None, aliases: Union[list, tuple] = None, cls: C = Command, no_global_checks=False
+    *, name: str = None, aliases: Union[list, tuple] = None, cls: type[C] = Command, no_global_checks=False
 ) -> Callable[[Callable], C]:
     if cls and not inspect.isclass(cls):
         raise TypeError(f"cls must be of type <class> not <{type(cls)}>")


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary
<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->

previously the typing of function `twitchio.ext.command.core.command` declared an argument `cls: C = Command`, but that was throwing a linting error (vscode pylance in my case) in any code that tried to create a command. it has been changed to `cls: type[C] = Command`.

demo code that showed the error before, and fixed after the change:

```python
from twitchio.ext import commands

class MyBot(commands.Bot):

    # Argument of type "type[Command]" cannot be assigned to parameter "cls" of type "C@command" in function "command"
    # Type "type[Command]" cannot be assigned to type "Command"
    #     "type[type]" is incompatible with "type[Command]"PylancereportGeneralTypeIssues

    @commands.command(name="hello", aliases=['hi'])
    async def hello(self, ctx: commands.Context):
        await ctx.send(f'Hello {ctx.author.name}!')
```

## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)