### PR TITLE
refactor eventsubws subscription error handling to not error on reconnect

### DIFF
--- a/twitchio/ext/eventsub/websocket.py
+++ b/twitchio/ext/eventsub/websocket.py
@@ -122,7 +122,12 @@ class Websocket:
                 obj.created.set_result((False, e.status))
 
             else:
-                logger.error("An error (%s %s) occurred while attempting to resubscribe to an event on reconnect: %s", e.status, e.reason, e.message)
+                logger.error(
+                    "An error (%s %s) occurred while attempting to resubscribe to an event on reconnect: %s",
+                    e.status,
+                    e.reason,
+                    e.message,
+                )
 
             return None
 

--- a/twitchio/ext/eventsub/websocket.py
+++ b/twitchio/ext/eventsub/websocket.py
@@ -4,12 +4,13 @@ import asyncio
 import logging
 
 import aiohttp
-from typing import Optional, TYPE_CHECKING, Tuple, Type, Dict, Callable, Generic, TypeVar, Awaitable, Union, cast, List, Literal
+from typing import Optional, TYPE_CHECKING, Tuple, Type, Dict, Callable, Generic, TypeVar, Awaitable, Union, cast, List
 from . import models, http
 from .models import _loads
 from twitchio import PartialUser, Unauthorized, HTTPException
 
 if TYPE_CHECKING:
+    from typing_extensions import Literal
     from twitchio import Client
 
 logger = logging.getLogger("twitchio.ext.eventsub.ws")

--- a/twitchio/ext/eventsub/websocket.py
+++ b/twitchio/ext/eventsub/websocket.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 
 import aiohttp
-from typing import Optional, TYPE_CHECKING, Tuple, Type, Dict, Callable, Generic, TypeVar, Awaitable, Union, cast, List
+from typing import Optional, TYPE_CHECKING, Tuple, Type, Dict, Callable, Generic, TypeVar, Awaitable, Union, cast, List, Literal
 from . import models, http
 from .models import _loads
 from twitchio import PartialUser, Unauthorized, HTTPException
@@ -32,7 +32,7 @@ class _Subscription:
         self.token = token
         self.subscription_id: Optional[str] = None
         self.cost: Optional[int] = None
-        self.created: asyncio.Future[Tuple[bool, int]] | None = asyncio.Future()
+        self.created: asyncio.Future[Tuple[Literal[False], int] | Tuple[Literal[True], None]] | None = asyncio.Future()
 
 
 _T = TypeVar("_T")
@@ -117,18 +117,20 @@ class Websocket:
         try:
             resp = await self._http.create_websocket_subscription(obj.event, obj.condition, self._session_id, obj.token)
         except HTTPException as e:
-            assert obj.created
-            obj.created.set_result((False, e.status))  # type: ignore
+            if obj.created:
+                obj.created.set_result((False, e.status))
+
+            else:
+                logger.error("An error (%s %s) occurred while attempting to resubscribe to an event on reconnect: %s", e.status, e.reason, e.message)
+
             return None
 
-        else:
-            assert obj.created
-            obj.created.set_result((True, None))  # type: ignore
+        if obj.created:
+            obj.created.set_result((True, None))
 
         data = resp["data"][0]
-        cost = data["cost"]
         self.remaining_slots = resp["max_total_cost"] - resp["total_cost"]
-        obj.cost = cost
+        obj.cost = data["cost"]
 
         return data
 


### PR DESCRIPTION

<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

Fixes a crash where an optional Future can become `None`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes. (note: changelog is in my other pr)
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
