### PR TITLE
Fix token regeneration hooks not applying to the active request

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,15 @@
 :orphan:
 
-Master
+2.9.0
 =======
 - TwitchIO
+    - Additions
+        - Added :class:`~twitchio.AdSchedule`
+        - Added the new ad-related methods for :class:`~twitchio.PartialUser`:
+            - :func:`~twitchio.PartialUser.fetch_ad_schedule`
+            - :func:`~twitchio.PartialUser.snooze_ad`
+        - Added :func:`~twitchio.PartialUser.fetch_moderated_channels` to :class:`~twitchio.PartialUser`
+
     - Bug fixes
         - Fixed ``event_token_expired`` not applying to the current request.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,16 @@
 :orphan:
 
+Master
+=======
+- TwitchIO
+    - Bug fixes
+        - Fixed ``event_token_expired`` not applying to the current request.
+
+- ext.eventsub
+    - Bug fixes
+        - Fixed a crash where a Future could be None, causing unintentional errors.
+
+
 2.8.2
 ======
 - ext.commands

--- a/twitchio/ext/eventsub/websocket.py
+++ b/twitchio/ext/eventsub/websocket.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 
 import aiohttp
-from typing import Optional, TYPE_CHECKING, Tuple, Type, Dict, Callable, Generic, TypeVar, Awaitable, Union, cast, List
+from typing import Optional, TYPE_CHECKING, Tuple, Type, Dict, Callable, Generic, TypeVar, Awaitable, Union, cast, List, Literal
 from . import models, http
 from .models import _loads
 from twitchio import PartialUser, Unauthorized, HTTPException
@@ -32,7 +32,7 @@ class _Subscription:
         self.token = token
         self.subscription_id: Optional[str] = None
         self.cost: Optional[int] = None
-        self.created: asyncio.Future[Tuple[bool, int]] | None = asyncio.Future()
+        self.created: asyncio.Future[Tuple[Literal[False], int] | Tuple[Literal[True], None]] | None = asyncio.Future()
 
 
 _T = TypeVar("_T")
@@ -117,18 +117,20 @@ class Websocket:
         try:
             resp = await self._http.create_websocket_subscription(obj.event, obj.condition, self._session_id, obj.token)
         except HTTPException as e:
-            assert obj.created
-            obj.created.set_result((False, e.status))  # type: ignore
+            if obj.created:
+                obj.created.set_result((False, e.status))
+
+            else:
+                logger.error("An error (%s %s) occurred while attempting to resubscribe to an event on reconnect: %s", e.status, e.reason, e.message)
+
             return None
 
-        else:
-            assert obj.created
-            obj.created.set_result((True, None))  # type: ignore
+        if obj.created:
+            obj.created.set_result((True, None))
 
         data = resp["data"][0]
-        cost = data["cost"]
         self.remaining_slots = resp["max_total_cost"] - resp["total_cost"]
-        obj.cost = cost
+        obj.cost = data["cost"]
 
         return data
 

--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -121,22 +121,8 @@ class TwitchHTTP:
             raise errors.NoClientID("A Client ID is required to use the Twitch API")
         headers = route.headers or {}
 
-        if force_app_token and "Authorization" not in headers:
-            if not self.client_secret:
-                raise errors.NoToken(
-                    "An app access token is required for this route, please provide a client id and client secret"
-                )
-            if self.app_token is None:
-                await self._generate_login()
-                headers["Authorization"] = f"Bearer {self.app_token}"
-        elif not self.token and not self.client_secret and "Authorization" not in headers:
-            raise errors.NoToken(
-                "Authorization is required to use the Twitch API. Pass token and/or client_secret to the Client constructor"
-            )
-        if "Authorization" not in headers:
-            if not self.token:
-                await self._generate_login()
-            headers["Authorization"] = f"Bearer {self.token}"
+        await self._apply_auth(headers, force_app_token, False)
+
         headers["Client-ID"] = self.client_id
 
         if not self.session:
@@ -165,7 +151,7 @@ class TwitchHTTP:
                     q = [("after", cursor), *q]
                 q = [("first", get_limit()), *q]
                 path = path.with_query(q)
-            body, is_text = await self._request(route, path, headers)
+            body, is_text = await self._request(route, path, headers, force_app_token=force_app_token)
             if is_text:
                 return body
             if full_body:
@@ -182,7 +168,26 @@ class TwitchHTTP:
             is_finished = reached_limit() if limit is not None else True if paginate else True
         return data
 
-    async def _request(self, route, path, headers, utilize_bucket=True):
+    async def _apply_auth(self, headers: dict, force_app_token: bool, force_apply: bool) -> None:
+        if force_app_token and "Authorization" not in headers:
+            if not self.client_secret:
+                raise errors.NoToken(
+                    "An app access token is required for this route, please provide a client id and client secret"
+                )
+            if self.app_token is None:
+                await self._generate_login()
+                headers["Authorization"] = f"Bearer {self.app_token}"
+        elif not self.token and not self.client_secret and "Authorization" not in headers:
+            raise errors.NoToken(
+                "Authorization is required to use the Twitch API. Pass token and/or client_secret to the Client constructor"
+            )
+        if "Authorization" not in headers or force_apply:
+            if not self.token:
+                await self._generate_login()
+            
+            headers["Authorization"] = f"Bearer {self.token}"
+
+    async def _request(self, route, path, headers, utilize_bucket=True, force_app_token: bool = False):
         reason = None
 
         for attempt in range(5):
@@ -224,6 +229,7 @@ class TwitchHTTP:
                     if "Invalid OAuth token" in message_json.get("message", ""):
                         try:
                             await self._generate_login()
+                            await self._apply_auth(headers, force_app_token, True)
                             continue
                         except:
                             raise errors.Unauthorized(

--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -184,7 +184,7 @@ class TwitchHTTP:
         if "Authorization" not in headers or force_apply:
             if not self.token:
                 await self._generate_login()
-            
+
             headers["Authorization"] = f"Bearer {self.token}"
 
     async def _request(self, route, path, headers, utilize_bucket=True, force_app_token: bool = False):


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

This fixes the `event_token_expired` hook not applying to the existing request.
Ignore the eventsub commit/revert.

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
