### PR TITLE
Fix fetch_markers passing list instead of dict

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,9 @@
 
 2.10.0
 =======
+- TwitchIO
+    - Bug fixes
+        - fix: :func:`~twitchio.PartialUser.fetch_markers` was passing list of one element from payload, now just passes element
 - ext.eventsub
     - Additions
         - Added :method:`Twitchio.ext.eventsub.EventSubClient.subscribe_channel_unban_request_create <EventSubClient.subscribe_channel_unban_request_create>` / 
@@ -17,7 +20,6 @@
 
     - Bug fixes
         - fix: :func:`~twitchio.PartialUser.fetch_moderated_channels` used ``user_`` prefix from payload, now uses ``broadcaster_`` instead
-        - fix: :func:`~twitchio.PartialUser.fetch_markers` was passing list of one element from payload, now just passes element
 
 - ext.commands
     - Bug fixes

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@
 
     - Bug fixes
         - fix: :func:`~twitchio.PartialUser.fetch_moderated_channels` used ``user_`` prefix from payload, now uses ``broadcaster_`` instead
+        - fix: :func:`~twitchio.PartialUser.fetch_markers` was passing list of one element from payload, now just passes element
 
 - ext.commands
     - Bug fixes

--- a/twitchio/user.py
+++ b/twitchio/user.py
@@ -770,7 +770,7 @@ class PartialUser:
 
         data = await self._http.get_stream_markers(token, user_id=str(self.id), video_id=video_id)
         if data:
-            return VideoMarkers(data[0]["videos"])
+            return VideoMarkers(data[0]["videos"][0])
 
     async def fetch_extensions(self, token: str):
         """|coro|


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->
The Twitch API describes the "videos" element in the response as "A list of videos that contain markers. The list contains a single video." Currently, that list is being passed when creating the VideoMarkers object, when only the first element of that "list" should be.

This fixes this issue that arises when retrieving markers:
```  File "C:\Users\Zari\AppData\Roaming\Python\Python312\site-packages\twitchio\models.py", line 814, in __init__
    self.markers = [Marker(d) for d in data["markers"]]
                                       ~~~~^^^^^^^^^^^
TypeError: list indices must be integers or slices, not str
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
