### PR TITLE
Sounds.ext fixes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,12 @@
             :method:`Twitchio.ext.eventsub.EventSubWSClient.subscribe_channel_unban_request_create <EventSubWSClient.subscribe_channel_unban_request_create>`
         - Added :method:`Twitchio.ext.eventsub.EventSubClient.subscribe_channel_unban_request_resolve <EventSubClient.subscribe_channel_unban_request_resolve>` / 
             :method:`Twitchio.ext.eventsub.EventSubWSClient.subscribe_channel_unban_request_resolve <EventSubWSClient.subscribe_channel_unban_request_resolve>`
+- ext.sounds
+    - Additions
+        - Added TinyTag as a dependency to support retrieving audio metadata using TinyTag in `ext.sounds.__init__.py`.
+        - added :method:`Twitchio.ext.sounds.rate setter.
+        - added :method:`Twitchio.ext.sounds.channels setter.
+
 
 2.9.2
 =======

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ Pygments
 furo
 pyaudio==0.2.11
 yt-dlp>=2022.2.4
+tinytag>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ with open("README.rst") as f:
 sounds = [
     "yt-dlp>=2022.2.4",
     'pyaudio==0.2.11; platform_system!="Windows"',
+    'tinytag>=1.9.0',
 ]
 speed = [
     "ujson>=5.2,<6",

--- a/twitchio/ext/sounds/__init__.py
+++ b/twitchio/ext/sounds/__init__.py
@@ -20,6 +20,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+
 import asyncio
 import audioop
 import dataclasses
@@ -33,6 +34,7 @@ from typing import Any, Callable, Coroutine, Dict, List, Optional, TypeVar, Unio
 
 import pyaudio
 from yt_dlp import YoutubeDL
+from tinytag import TinyTag
 
 
 __all__ = ("Sound", "AudioPlayer")
@@ -173,6 +175,9 @@ class Sound:
 
         elif isinstance(source, str):
             self.title = source
+            tag = TinyTag.get(source)
+            self._rate = tag.samplerate
+            self._channels = tag.channels
 
             self.proc = subprocess.Popen(
                 [
@@ -188,9 +193,6 @@ class Sound:
                 ],
                 stdout=subprocess.PIPE,
             )
-
-        self._channels = 2
-        self._rate = 48000
 
     @classmethod
     async def ytdl_search(cls, search: str, *, loop: Optional[asyncio.BaseEventLoop] = None):
@@ -216,10 +218,20 @@ class Sound:
         """The audio source channels."""
         return self._channels
 
+    @channels.setter
+    def channels(self, channels: int):
+        """Set audio source channels."""
+        self._channels = channels
+
     @property
     def rate(self):
         """The audio source sample rate."""
         return self._rate
+
+    @rate.setter
+    def rate(self, rate: int):
+        """Set audio source sample rate."""
+        self._rate = rate
 
     @property
     def source(self):


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->
edit:
Added TinyTag as a dependency to detect audio file meta data for channels and rate to auto set those values.
TinyTag is MIT and has no external dependencies of its own
## Pull request summary
This could be a solution to #358

The sample rate of audio for Sound is hard coded (it might have something to do with  YTDL, Im not sure), however if you create a sound using a local file 
```
Sound(source="my_audio.mp3")
```
it's possible and likely to have files with different sample rates. Ive personally run into this issue and have seen others run into it as well, and the only solution right now is to hack at the library code to change the sample rate manually.

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->
This PR just gives Sound.rate and Sound.channels a setter on each class property. Maybe in the future I can look at pulling sample meta data from the suppled audio file, but sometimes that can even be wrong so those class properties kind of need to be able to be set.


## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)


Im closing the other PR, I managed to mess up the other branch beyond repair lol. This is an identical PR to the one before.