### PR TITLE
Add `channel.ad_break.begin` for EventSub

### DIFF
--- a/docs/exts/eventsub.rst
+++ b/docs/exts/eventsub.rst
@@ -543,13 +543,13 @@ API Reference
 
 .. attributetable::: ChannelModerateData
 
-.. autoclass:: ChannelAdBreakBeginData
+.. autoclass:: ChannelModerateData
     :members:
     :inherited-members:
 
 .. attributetable::: ChannelAdBreakBeginData
 
-.. autoclass:: ChannelModerateData
+.. autoclass:: ChannelAdBreakBeginData
     :members:
     :inherited-members:
 

--- a/docs/exts/eventsub.rst
+++ b/docs/exts/eventsub.rst
@@ -234,6 +234,10 @@ This is a list of events dispatched by the eventsub ext.
 
     Called when a user donates to an active charity campaign.
 
+.. function:: event_eventsub_notification_channel_ad_break_begin(event: ChannelAdBreakBeginData)
+
+    Called when a user runs a midroll commercial break, either manually or automatically via ads manager.
+
 API Reference
 --------------
 
@@ -538,6 +542,12 @@ API Reference
     :inherited-members:
 
 .. attributetable::: ChannelModerateData
+
+.. autoclass:: ChannelAdBreakBeginData
+    :members:
+    :inherited-members:
+
+.. attributetable::: ChannelAdBreakBeginData
 
 .. autoclass:: ChannelModerateData
     :members:

--- a/twitchio/ext/eventsub/models.py
+++ b/twitchio/ext/eventsub/models.py
@@ -2195,6 +2195,36 @@ class SuspiciousUserUpdateData(EventData):
         self.trust_status: Literal["active_monitoring", "restricted", "none"] = data["low_trust_status"]
 
 
+class ChannelAdBreakBeginData(EventData):
+    """
+    An ad begin event.
+
+    Attributes
+    -----------
+    is_automatic: :class:`bool`
+        Whether the ad was run manually or automatically via ads manager.
+    broadcaster: :class:`~twitchio.PartialUser`
+        The channel where a midroll commercial break has started running.
+    requester: Optional[:class:`twitchio.PartialUser`]
+        The user who started the ad break. Will be ``None`` if ``is_automatic`` is ``True``.
+    duration: :class:`int`
+        The ad duration in seconds.
+    started_at: :class:`datetime.datetime`
+        When the ad began.
+    """
+
+    __slots__ = ("is_automatic", "broadcaster", "requester", "duration", "started_at")
+
+    def __init__(self, client: EventSubClient, data: dict) -> None:
+        self.is_automatic: bool = data["is_automatic"]
+        self.broadcaster: PartialUser = _transform_user(client, data, "broadcaster_user")
+        self.requester: Optional[PartialUser] = (
+            None if self.is_automatic else _transform_user(client, data, "requester_user")
+        )
+        self.duration: int = data["duration_seconds"]
+        self.started_at: datetime.datetime = _parse_datetime(data["started_at"])
+
+
 class AutoCustomReward:
     """
     A reward object for an Auto Reward Redeem.
@@ -2318,6 +2348,7 @@ _DataType = Union[
     ChannelModerateData,
     AutoRewardRedeem,
     ChannelVIPAddRemove,
+    ChannelAdBreakBeginData,
 ]
 
 
@@ -2409,6 +2440,8 @@ class _SubscriptionTypes(metaclass=_SubTypesMeta):
     user_update = "user.update", 1, UserUpdateData
 
     suspicious_user_update = "channel.suspicious_user.update", 1, SuspiciousUserUpdateData
+
+    channel_ad_break_begin = "channel.ad_break.begin", 1, ChannelAdBreakBeginData
 
 
 SubscriptionTypes = _SubscriptionTypes()

--- a/twitchio/ext/eventsub/server.py
+++ b/twitchio/ext/eventsub/server.py
@@ -344,6 +344,9 @@ class EventSubClient(web.Application):
     def subscribe_channel_vip_remove(self, broadcaster: Union[PartialUser, str, int]):
         return self._subscribe_with_broadcaster(models.SubscriptionTypes.channel_vip_remove, broadcaster)
 
+    def subscribe_channel_ad_break_begin(self, broadcaster: Union[PartialUser, str, int]):
+        return self._subscribe_with_broadcaster(models.SubscriptionTypes.channel_ad_break_begin, broadcaster)
+
     async def subscribe_user_authorization_granted(self):
         return await self._http.create_webhook_subscription(
             models.SubscriptionTypes.user_authorization_grant, {"client_id": self.client._http.client_id}

--- a/twitchio/ext/eventsub/websocket.py
+++ b/twitchio/ext/eventsub/websocket.py
@@ -578,3 +578,6 @@ class EventSubWSClient:
 
     async def subscribe_channel_vip_remove(self, broadcaster: Union[PartialUser, str, int], token: str):
         await self._subscribe_with_broadcaster(models.SubscriptionTypes.channel_vip_remove, broadcaster, token)
+
+    async def subscribe_channel_ad_break_begin(self, broadcaster: Union[PartialUser, str, int], token: str):
+        await self._subscribe_with_broadcaster(models.SubscriptionTypes.channel_ad_break_begin, broadcaster, token)


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->

Hey, I'm Irene Adler❤️ from discord, coming from a small discussion in #help - just threw together some implementation for `channel.ad_break.begin` subscription type for Event Sub. 

The link to twitch dev docs: https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelad_breakbegin

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    Little proof:
    ![image](https://github.com/user-attachments/assets/6d2e11f1-c73d-4131-ba0e-79e7fcf00994)
    - [X] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [X] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
