### PR TITLE
Support multiple cooldowns

### DIFF
--- a/twitchio/ext/commands/cooldowns.py
+++ b/twitchio/ext/commands/cooldowns.py
@@ -130,7 +130,7 @@ class Cooldown:
 
         self._cache = {}
 
-    def update_cooldown(self, key, now) -> int | None:
+    def _update_cooldown(self, key, now) -> int | None:
         cooldown = self._cache[key]
 
         if cooldown["tokens"] == self._rate:
@@ -197,4 +197,4 @@ class Cooldown:
             if not key in self._cache:
                 self._cache[key] = {"tokens": 0, "start_time": now, "next_start_time": None}
 
-            return self.update_cooldown(key, now)
+            return self._update_cooldown(key, now)


### PR DESCRIPTION
* Add support for multiple cooldowns per command

<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->

This adds support for multiple cooldowns for a given command. It also adds support for turbo, vip, and broadcaster buckets. It checks each cooldown individually and if _any_ of the cooldowns have expired, the command is invoked. If none of the cooldowns have expired, it raises a `CommandOnCooldown` exception using the time of the cooldown which will expire first.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
