### PR TITLE
Added new parameters to function twitchio.PartialUser.modify_stream for delay and tags

### DIFF
--- a/twitchio/http.py
+++ b/twitchio/http.py
@@ -768,16 +768,20 @@ class TwitchHTTP:
         game_id: str = None,
         language: str = None,
         title: str = None,
+        delay: int = None,
+        tags: List[str] = None,
         content_classification_labels: List[Dict[str, Union[str, bool]]] = None,
         is_branded_content: bool = None,
     ):
-        assert any((game_id, language, title, content_classification_labels, is_branded_content))
+        assert any((game_id, language, title, delay, tags, content_classification_labels, is_branded_content))
         body = {
             k: v
             for k, v in {
                 "game_id": game_id,
                 "broadcaster_language": language,
                 "title": title,
+                "delay": delay,
+                "tags": tags,
                 "is_branded_content": is_branded_content,
             }.items()
             if v is not None

--- a/twitchio/user.py
+++ b/twitchio/user.py
@@ -958,6 +958,8 @@ class PartialUser:
         game_id: int = None,
         language: str = None,
         title: str = None,
+        delay: int = None,
+        tags: List[str] = None,
         content_classification_labels: List[Dict[str, Union[str, bool]]] = None,
         is_branded_content: bool = None,
     ):
@@ -975,6 +977,10 @@ class PartialUser:
             Optional language of the channel. A language value must be either the ISO 639-1 two-letter code for a supported stream language or “other”.
         title: :class:`str`
             Optional title of the stream.
+        delay: :class:`int`
+            Optional the number of seconds you want your broadcast buffered before streaming it live.
+        tags: List[:class:`str`]
+            Optional a list of channel-defined tags to apply to the channel. To remove all tags from the channel, set tags to an empty array.
         content_classification_labels: List[Dict[:class:`str`, Union[:class:`str`, :class:`bool`]]]
             List of labels that should be set as the Channel's CCLs.
         is_branded_content: :class:`bool`
@@ -997,6 +1003,8 @@ class PartialUser:
             game_id=game_id,
             language=language,
             title=title,
+            delay=delay,
+            tags=tags,
             content_classification_labels=content_classification_labels,
             is_branded_content=is_branded_content,
         )


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

This PR adds two parameters to the `twitchio.PartialUser.modify_stream()` function. These parameters are described at [https://dev.twitch.tv/docs/api/reference/#modify-channel-information](https://dev.twitch.tv/docs/api/reference/#modify-channel-information):
- `delay`: The number of seconds you want your broadcast buffered before streaming it live. The delay helps ensure fairness during competitive play. Only users with Partner status may set this field. The maximum delay is 900 seconds (15 minutes).
- `tags`: A list of channel-defined tags to apply to the channel. To remove all tags from the channel, set tags to an empty array. Tags help identify the content that the channel streams. [Learn More](https://help.twitch.tv/s/article/guide-to-tags)

Changelog:
- TwitchIO
    - Additions
        - Added new parameters to :func:`~twitchio.PartialUser.modify_stream` for ``delay`` and ``tags``

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
    - [X] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [X] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [X] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
