### PR TITLE
fix 404 in readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ TwitchIO is more than a simple wrapper, providing ease of use when accessing the
    
 Getting Started
 --------------------------------
-[Installing](https://twitchio.dev/en/getting-started/installing.html)
+[Installing](https://twitchio.dev/en/latest/getting-started/installing.html)
 
-[Quickstart](https://twitchio.dev/en/getting-started/quickstart.html)
+[Quickstart](https://twitchio.dev/en/latest/getting-started/quickstart.html)
 
 [Examples](/examples)
 


### PR DESCRIPTION

## Description

The url seems to be missing a `/latest`.

Also, I suggest: 
 - creating a `2.x` version on readthedocs and making `stable` point to it.
 - make the default readthedocs version point to `stable`.
 - when v3 becomes stable: create a `3.x` readthedocs version and point `stable` to it instead.
 - when v3 becomes stable: update the readme to have doc links point to `stable`. (they currently point to `latest`)



## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
