### PR TITLE
Add SSLContext arg to aiohttp adapter

### DIFF
--- a/docs/references/events.rst
+++ b/docs/references/events.rst
@@ -540,7 +540,7 @@ Channel / Broadcaster
     
     Corresponds to the Twitch EventSub subscriptions :es-docs:`Channel Raid <channelraid>`
     
-    You must subscribe to EventSub with :class:`~twitchio.eventsub.ChannelCheerSubscription`
+    You must subscribe to EventSub with :class:`~twitchio.eventsub.ChannelRaidSubscription`
     for each required broadcaster to receive this event.
 
     :param twitchio.ChannelRaid payload: The EventSub payload received for this event.

--- a/twitchio/web/aio_adapter.py
+++ b/twitchio/web/aio_adapter.py
@@ -139,6 +139,7 @@ class AiohttpAdapter(BaseAdapter, web.Application):
         domain: str | None = None,
         eventsub_path: str | None = None,
         eventsub_secret: str | None = None,
+        ssl_context: SSLContext | None = None,
     ) -> None:
         super().__init__()
         self._runner: web.AppRunner | None = None
@@ -159,6 +160,8 @@ class AiohttpAdapter(BaseAdapter, web.Application):
 
         path: str = eventsub_path.removeprefix("/").removesuffix("/") if eventsub_path else "callback"
         self._eventsub_path: str = f"/{path}"
+
+        self._ssl_context: SSLContext = ssl_context 
 
         self._runner_task: asyncio.Task[None] | None = None
         self.startup = self.event_startup
@@ -210,7 +213,7 @@ class AiohttpAdapter(BaseAdapter, web.Application):
         self._runner = web.AppRunner(self, access_log=None, handle_signals=True)
         await self._runner.setup()
 
-        site: web.TCPSite = web.TCPSite(self._runner, host or self._host, port or self._port)
+        site: web.TCPSite = web.TCPSite(self._runner, host or self._host, port or self._port, ssl_context=self._ssl_context)
         self._runner_task = asyncio.create_task(site.start(), name=f"twitchio-web-adapter:{self.__class__.__qualname__}")
 
     async def eventsub_callback(self, request: web.Request) -> web.Response:

--- a/twitchio/web/aio_adapter.py
+++ b/twitchio/web/aio_adapter.py
@@ -101,6 +101,8 @@ class AiohttpAdapter(BaseAdapter, web.Application):
         An optional :class:`str` passed to use as the EventSub secret. It is recommended you pass this parameter when using
         an adapter for EventSub, as it will reset upon restarting otherwise. You can generate token safe secrets with the
         :mod:`secrets` module.
+    ssl_context: SSLContext | None
+        An optional :class:`ssl.SSLContext` passed to the adapter, configuring SSL encryption for the HTTP routes.
 
     Examples
     --------

--- a/twitchio/web/aio_adapter.py
+++ b/twitchio/web/aio_adapter.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import ssl
 import logging
 from collections import deque
 from typing import TYPE_CHECKING, Any, cast
@@ -101,8 +102,8 @@ class AiohttpAdapter(BaseAdapter, web.Application):
         An optional :class:`str` passed to use as the EventSub secret. It is recommended you pass this parameter when using
         an adapter for EventSub, as it will reset upon restarting otherwise. You can generate token safe secrets with the
         :mod:`secrets` module.
-    ssl_context: SSLContext | None
-        An optional :class:`ssl.SSLContext` passed to the adapter, configuring SSL encryption for the HTTP routes.
+    ssl_context: ssl.SSLContext | None
+        An optional :class:`ssl.SSLContext` passed to the adapter. If SSL is setup via a front-facing web server such as NGINX, you should leave this as None.
 
     Examples
     --------
@@ -141,7 +142,7 @@ class AiohttpAdapter(BaseAdapter, web.Application):
         domain: str | None = None,
         eventsub_path: str | None = None,
         eventsub_secret: str | None = None,
-        ssl_context: SSLContext | None = None,
+        ssl_context: ssl.SSLContext | None = None,
     ) -> None:
         super().__init__()
         self._runner: web.AppRunner | None = None
@@ -163,7 +164,7 @@ class AiohttpAdapter(BaseAdapter, web.Application):
         path: str = eventsub_path.removeprefix("/").removesuffix("/") if eventsub_path else "callback"
         self._eventsub_path: str = f"/{path}"
 
-        self._ssl_context: SSLContext = ssl_context 
+        self._ssl_context: ssl.SSLContext = ssl_context 
 
         self._runner_task: asyncio.Task[None] | None = None
         self.startup = self.event_startup

--- a/twitchio/web/aio_adapter.py
+++ b/twitchio/web/aio_adapter.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import asyncio
 import datetime
-import ssl
 import logging
 from collections import deque
 from typing import TYPE_CHECKING, Any, cast
@@ -46,7 +45,7 @@ from .utils import MESSAGE_TYPES, BaseAdapter, FetchTokenPayload, verify_message
 if TYPE_CHECKING:
     from ..authentication import AuthorizationURLPayload, UserTokenPayload
     from ..client import Client
-
+    from ssl import SSLContext
 
 __all__ = ("AiohttpAdapter",)
 
@@ -102,8 +101,8 @@ class AiohttpAdapter(BaseAdapter, web.Application):
         An optional :class:`str` passed to use as the EventSub secret. It is recommended you pass this parameter when using
         an adapter for EventSub, as it will reset upon restarting otherwise. You can generate token safe secrets with the
         :mod:`secrets` module.
-    ssl_context: ssl.SSLContext | None
-        An optional :class:`ssl.SSLContext` passed to the adapter. If SSL is setup via a front-facing web server such as NGINX, you should leave this as None.
+    ssl_context: SSLContext | None
+        An optional :class:`SSLContext` passed to the adapter. If SSL is setup via a front-facing web server such as NGINX, you should leave this as None.
 
     Examples
     --------
@@ -142,7 +141,7 @@ class AiohttpAdapter(BaseAdapter, web.Application):
         domain: str | None = None,
         eventsub_path: str | None = None,
         eventsub_secret: str | None = None,
-        ssl_context: ssl.SSLContext | None = None,
+        ssl_context: SSLContext | None = None,
     ) -> None:
         super().__init__()
         self._runner: web.AppRunner | None = None
@@ -164,7 +163,7 @@ class AiohttpAdapter(BaseAdapter, web.Application):
         path: str = eventsub_path.removeprefix("/").removesuffix("/") if eventsub_path else "callback"
         self._eventsub_path: str = f"/{path}"
 
-        self._ssl_context: ssl.SSLContext = ssl_context 
+        self._ssl_context: SSLContext | None = ssl_context 
 
         self._runner_task: asyncio.Task[None] | None = None
         self.startup = self.event_startup

--- a/twitchio/web/aio_adapter.py
+++ b/twitchio/web/aio_adapter.py
@@ -43,9 +43,10 @@ from .utils import MESSAGE_TYPES, BaseAdapter, FetchTokenPayload, verify_message
 
 
 if TYPE_CHECKING:
+    from ssl import SSLContext
     from ..authentication import AuthorizationURLPayload, UserTokenPayload
     from ..client import Client
-    from ssl import SSLContext
+
 
 __all__ = ("AiohttpAdapter",)
 
@@ -163,7 +164,7 @@ class AiohttpAdapter(BaseAdapter, web.Application):
         path: str = eventsub_path.removeprefix("/").removesuffix("/") if eventsub_path else "callback"
         self._eventsub_path: str = f"/{path}"
 
-        self._ssl_context: SSLContext | None = ssl_context 
+        self._ssl_context: SSLContext | None = ssl_context
 
         self._runner_task: asyncio.Task[None] | None = None
         self.startup = self.event_startup

--- a/twitchio/web/aio_adapter.py
+++ b/twitchio/web/aio_adapter.py
@@ -44,6 +44,7 @@ from .utils import MESSAGE_TYPES, BaseAdapter, FetchTokenPayload, verify_message
 
 if TYPE_CHECKING:
     from ssl import SSLContext
+
     from ..authentication import AuthorizationURLPayload, UserTokenPayload
     from ..client import Client
 


### PR DESCRIPTION
Pass an SSLContext to the aiohttp adapter to create a valid SSL endpoint for OAuth callback.

## Description

I needed the built-in `aiohttp` adapter to provide an SSL configuration so I could do OAuth with a callback without proxying my traffic through nginx. This can be done by passing an `SSLContext` object to the constructor of `web.TCPSite`.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution