### PR TITLE
docs: make username propriety  more findable

### DIFF
--- a/twitchio/user.py
+++ b/twitchio/user.py
@@ -88,7 +88,7 @@ class PartialUser:
     id: str | int
         The user's ID.
     name: str | None
-        The user's name. In most cases, this is provided. There are however, rare cases where it is not.
+        The user's name. Also known as *username* or *login name*. In most cases, this is provided. There are however, rare cases where it is not.
     display_name: str | None
         The user's display name in chat. In most cases, this is provided otherwise fallsback to `name`. There are however, rare cases where it is not.
     """
@@ -3459,7 +3459,7 @@ class User(PartialUser):
     id: str
         The user's ID.
     name: str | None
-        The user's name. In most cases, this is provided. There are however, rare cases where it is not.
+        The user's name. Also known as *username* or *login name*. In most cases, this is provided. There are however, rare cases where it is not.
     display_name: str
         The display name of the user.
     type: Literal["admin", "global_mod", "staff", ""]


### PR DESCRIPTION
For regular twitch users, this propriety is known as `username`, but the helix api definitions refer to as `login name`.

This makes it easier to find the relevant twitch api section from reading the twitchio docs, and vice versa.

<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x ] If code changes were made then they have been tested.
    - [ x] I have updated the documentation to reflect the changes.
    - [x ] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x ] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
