### PR TITLE
Add Generic to Context

### DIFF
--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from twitchio.user import User
 
     from .components import Component
-    from .types_ import AutoBotOptions, BotOptions
+    from .types_ import AutoBotOptions, BotOptions, BotT
 
     PrefixT: TypeAlias = str | Iterable[str] | Callable[["Bot", "ChatMessage"], Coroutine[Any, Any, str | Iterable[str]]]
 
@@ -433,7 +433,7 @@ class Bot(Mixin[None], Client):
     async def _process_commands(
         self, payload: ChatMessage | ChannelPointsRedemptionAdd | ChannelPointsRedemptionUpdate
     ) -> None:
-        ctx: Context = self.get_context(payload)
+        ctx = self.get_context(payload)
         await self.invoke(ctx)
 
     async def process_commands(
@@ -441,7 +441,7 @@ class Bot(Mixin[None], Client):
     ) -> None:
         await self._process_commands(payload)
 
-    async def invoke(self, ctx: Context) -> None:
+    async def invoke(self, ctx: Context[BotT]) -> None:
         try:
             await ctx.invoke()
         except CommandError as e:
@@ -482,7 +482,7 @@ class Bot(Mixin[None], Client):
         msg = f'Ignoring exception in command "{payload.context.command}":\n'
         logger.error(msg, exc_info=payload.exception)
 
-    async def before_invoke(self, ctx: Context) -> None:
+    async def before_invoke(self, ctx: Context[BotT]) -> None:
         """A pre invoke hook for all commands that have been added to the bot.
 
         Commands from :class:`~.commands.Component`'s are included, however if you wish to control them separately,
@@ -513,7 +513,7 @@ class Bot(Mixin[None], Client):
             The context associated with command invocation, before being passed to the command.
         """
 
-    async def after_invoke(self, ctx: Context) -> None:
+    async def after_invoke(self, ctx: Context[BotT]) -> None:
         """A post invoke hook for all commands that have been added to the bot.
 
         Commands from :class:`~.commands.Component`'s are included, however if you wish to control them separately,
@@ -544,7 +544,7 @@ class Bot(Mixin[None], Client):
             The context associated with command invocation, after being passed through the command.
         """
 
-    async def global_guard(self, ctx: Context, /) -> bool:
+    async def global_guard(self, ctx: Context[BotT], /) -> bool:
         """|coro|
 
         A global guard applied to all commmands added to the bot.

--- a/twitchio/ext/commands/components.py
+++ b/twitchio/ext/commands/components.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from .context import Context
-    from .types_ import ComponentOptions
+    from .types_ import BotT, ComponentOptions
 
 
 __all__ = ("Component",)
@@ -262,13 +262,13 @@ class Component(_MetaComponent):
         This method is intended to be overwritten, by default it does nothing.
         """
 
-    async def component_before_invoke(self, ctx: Context) -> None:
+    async def component_before_invoke(self, ctx: Context[BotT]) -> None:
         """Hook called before a :class:`~.commands.Command` in this Component is invoked.
 
         Similar to :meth:`~.commands.Bot.before_invoke` but only applies to commands in this Component.
         """
 
-    async def component_after_invoke(self, ctx: Context) -> None:
+    async def component_after_invoke(self, ctx: Context[BotT]) -> None:
         """Hook called after a :class:`~.commands.Command` has successfully invoked in this Component.
 
         Similar to :meth:`~.commands.Bot.after_invoke` but only applies to commands in this Component.

--- a/twitchio/ext/commands/context.py
+++ b/twitchio/ext/commands/context.py
@@ -25,12 +25,13 @@ SOFTWARE.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias
 
 from twitchio.models.eventsub_ import ChannelPointsRedemptionAdd, ChannelPointsRedemptionUpdate, ChatMessage
 
 from .core import CommandErrorPayload, ContextType, RewardCommand, RewardStatus
 from .exceptions import *
+from .types_ import BotT
 from .view import StringView
 
 
@@ -50,7 +51,7 @@ if TYPE_CHECKING:
     PrefixT: TypeAlias = str | Iterable[str] | Callable[[Bot, ChatMessage], Coroutine[Any, Any, str | Iterable[str]]]
 
 
-class Context:
+class Context(Generic[BotT]):
     """The Context class constructed when a message or reward redemption in the respective events is received and processed
     in a :class:`~.commands.Bot`.
 
@@ -77,10 +78,10 @@ class Context:
         self,
         payload: ChatMessage | ChannelPointsRedemptionAdd | ChannelPointsRedemptionUpdate,
         *,
-        bot: Bot,
+        bot: BotT,
     ) -> None:
         self._payload: ChatMessage | ChannelPointsRedemptionAdd | ChannelPointsRedemptionUpdate = payload
-        self._bot: Bot = bot
+        self._bot = bot
         self._component: Component | None = None
         self._prefix: str | None = None
 
@@ -220,7 +221,7 @@ class Context:
         return self.broadcaster
 
     @property
-    def bot(self) -> Bot:
+    def bot(self) -> BotT:
         """Property returning the :class:`~.commands.Bot` object."""
         return self._bot
 

--- a/twitchio/ext/commands/converters.py
+++ b/twitchio/ext/commands/converters.py
@@ -34,6 +34,7 @@ from .exceptions import *
 if TYPE_CHECKING:
     from .bot import Bot
     from .context import Context
+    from .types_ import BotT
 
 __all__ = ("_BaseConverter",)
 
@@ -67,7 +68,7 @@ class _BaseConverter:
 
         return result
 
-    async def _user(self, context: Context, arg: str) -> User:
+    async def _user(self, context: Context[BotT], arg: str) -> User:
         arg = arg.lower()
         users: list[User]
         msg: str = 'Failed to convert "{}" to User. A User with the ID or login could not be found.'

--- a/twitchio/ext/commands/cooldowns.py
+++ b/twitchio/ext/commands/cooldowns.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     import twitchio
 
     from .context import Context
+    from .types_ import BotT
 
 
 __all__ = ("BaseCooldown", "Bucket", "BucketType", "Cooldown", "GCRACooldown")
@@ -65,7 +66,7 @@ class BucketType(enum.Enum):
     channel = 2
     chatter = 3
 
-    def get_key(self, payload: twitchio.ChatMessage | Context) -> Any:
+    def get_key(self, payload: twitchio.ChatMessage | Context[BotT]) -> Any:
         if self is BucketType.user:
             return payload.chatter.id
 
@@ -75,7 +76,7 @@ class BucketType(enum.Enum):
         elif self is BucketType.chatter:
             return (payload.broadcaster.id, payload.chatter.id)
 
-    def __call__(self, payload: twitchio.ChatMessage | Context) -> Any:
+    def __call__(self, payload: twitchio.ChatMessage | Context[BotT]) -> Any:
         return self.get_key(payload)
 
 

--- a/twitchio/ext/commands/types_.py
+++ b/twitchio/ext/commands/types_.py
@@ -22,16 +22,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from typing import TYPE_CHECKING, Any, TypedDict, TypeVar
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, Union
 
 from twitchio.types_.options import AutoClientOptions, ClientOptions
 
 
 if TYPE_CHECKING:
+    from .bot import AutoBot, Bot
     from .components import Component
+    from .context import Context
 
 
 Component_T = TypeVar("Component_T", bound="Component | None")
+
+ContextT = TypeVar("ContextT", bound="Context[Any]")
+ContextT_co = TypeVar("ContextT_co", bound="Context[Any]", covariant=True)
+
+_Bot = Union["Bot", "AutoBot"]
+BotT = TypeVar("BotT", bound=_Bot, covariant=True)
 
 
 class CommandOptions(TypedDict, total=False):


### PR DESCRIPTION
## Description

Allows `Context` to be used as a `Generic` with `commands.Bot` and `commands.AutoBot`. 

This allows accessing correct typing information for your `Bot` in `Context`.

```py
class MyBot(commands.Bot):
    thing: int

# Anywhere Context is available...
ctx: commands.Context[MyBot]
reveal_type(ctx.bot.thing)  # Type of "ctx.bot.thing" is "int"
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
