### PR TITLE
Feature/payload respond

### DIFF
--- a/docs/getting-started/changelog.rst
+++ b/docs/getting-started/changelog.rst
@@ -21,6 +21,68 @@ Changelog
         - :meth:`twitchio.Clip.fetch_video` now properly returns ``None`` when the :class:`twitchio.Clip` has no ``video_id``.
         - :class:`twitchio.ChatterColor` no longer errors whan no valid hex is provided by Twitch.
 
+- twitchio.eventsub
+    - Additions
+        - Added :meth:`twitchio.AutomodMessageHold.respond`
+        - Added :meth:`twitchio.AutomodSettingsUpdate.respond`
+        - Added :meth:`twitchio.AutomodTermsUpdate.respond`
+        - Added :meth:`twitchio.ChannelBitsUse.respond`
+        - Added :meth:`twitchio.ChannelUpdate.respond`
+        - Added :meth:`twitchio.ChannelFollow.respond`
+        - Added :meth:`twitchio.ChannelAdBreakBegin.respond`
+        - Added :meth:`twitchio.ChannelChatClear.respond`
+        - Added :meth:`twitchio.ChannelChatClearUserMessages.respond`
+        - Added :meth:`twitchio.ChatMessage.respond`
+        - Added :meth:`twitchio.ChatNotification.respond`
+        - Added :meth:`twitchio.ChatMessageDelete.respond`
+        - Added :meth:`twitchio.ChatSettingsUpdate.respond`
+        - Added :meth:`twitchio.SharedChatSessionBegin.respond`
+        - Added :meth:`twitchio.SharedChatSessionUpdate.respond`
+        - Added :meth:`twitchio.SharedChatSessionEnd.respond`
+        - Added :meth:`twitchio.ChannelSubscribe.respond`
+        - Added :meth:`twitchio.ChannelSubscriptionEnd.respond`
+        - Added :meth:`twitchio.ChannelSubscriptionGift.respond`
+        - Added :meth:`twitchio.ChannelSubscriptionMessage.respond`
+        - Added :meth:`twitchio.ChannelCheer.respond`
+        - Added :meth:`twitchio.ChannelBan.respond`
+        - Added :meth:`twitchio.ChannelUnban.respond`
+        - Added :meth:`twitchio.ChannelUnbanRequest.respond`
+        - Added :meth:`twitchio.ChannelUnbanRequestResolve.respond`
+        - Added :meth:`twitchio.ChannelModerate.respond`
+        - Added :meth:`twitchio.ChannelModeratorAdd.respond`
+        - Added :meth:`twitchio.ChannelModeratorRemove.respond`
+        - Added :meth:`twitchio.ChannelPointsAutoRedeemAdd.respond`
+        - Added :meth:`twitchio.ChannelPointsReward.respond`
+        - Added :meth:`twitchio.ChannelPointsRedemptionAdd.respond`
+        - Added :meth:`twitchio.ChannelPointsRedemptionUpdate.respond`
+        - Added :meth:`twitchio.ChannelPollBegin.respond`
+        - Added :meth:`twitchio.ChannelPollProgress.respond`
+        - Added :meth:`twitchio.ChannelPollEnd.respond`
+        - Added :meth:`twitchio.ChannelPredictionBegin.respond`
+        - Added :meth:`twitchio.ChannelPredictionProgress.respond`
+        - Added :meth:`twitchio.ChannelPredictionLock.respond`
+        - Added :meth:`twitchio.ChannelPredictionEnd.respond`
+        - Added :meth:`twitchio.SuspiciousUserUpdate.respond`
+        - Added :meth:`twitchio.SuspiciousUserMessage.respond`
+        - Added :meth:`twitchio.ChannelVIPAdd.respond`
+        - Added :meth:`twitchio.ChannelVIPRemove.respond`
+        - Added :meth:`twitchio.ChannelWarningAcknowledge.respond`
+        - Added :meth:`twitchio.ChannelWarningSend.respond`
+        - Added :meth:`twitchio.BaseCharityCampaign.respond`
+        - Added :meth:`twitchio.CharityCampaignDonation.respond`
+        - Added :meth:`twitchio.GoalBegin.respond`
+        - Added :meth:`twitchio.GoalProgress.respond`
+        - Added :meth:`twitchio.GoalEnd.respond`
+        - Added :meth:`twitchio.HypeTrainBegin.respond`
+        - Added :meth:`twitchio.HypeTrainProgress.respond`
+        - Added :meth:`twitchio.HypeTrainEnd.respond`
+        - Added :meth:`twitchio.ShieldModeBegin.respond`
+        - Added :meth:`twitchio.ShieldModeEnd.respond`
+        - Added :meth:`twitchio.ShoutoutCreate.respond`
+        - Added :meth:`twitchio.ShoutoutReceive.respond`
+        - Added :meth:`twitchio.StreamOnline.respond`
+        - Added :meth:`twitchio.StreamOffline.respond`
+
 - ext.commands
     - Additions
         - Added :class:`~twitchio.ext.commands.Converter`

--- a/twitchio/client.py
+++ b/twitchio/client.py
@@ -477,7 +477,7 @@ class Client:
         token: str | None
             An optional app token to use instead of generating one automatically.
         with_adapter: bool
-            Whether to start and run a web adapter. Defaults to `True`. See: ... for more information.
+            Whether to start and run a web adapter. Defaults to `True`.
         load_tokens: bool
             Optional bool which indicates whether the :class:`Client` should call :meth:`.load_tokens` during
             :meth:`.login` automatically. Defaults to ``True``.
@@ -546,7 +546,7 @@ class Client:
         token: str | None
             An optional app token to use instead of generating one automatically.
         with_adapter: bool
-            Whether to start and run a web adapter. Defaults to `True`. See: ... for more information.
+            Whether to start and run a web adapter. Defaults to `True`.
         load_tokens: bool
             Optional bool which indicates whether the :class:`Client` should call :meth:`.load_tokens` during
             :meth:`.login` automatically. Defaults to ``True``.
@@ -2214,10 +2214,6 @@ class Client:
 
         Subscribe to an EventSub Event via Websockets.
 
-        .. note::
-
-            See: ... for more information and recipes on using eventsub.
-
         Parameters
         ----------
         payload: :class:`twitchio.eventsub.SubscriptionPayload`
@@ -2344,10 +2340,6 @@ class Client:
         """|coro|
 
         Subscribe to an EventSub Event via Webhook.
-
-        .. note::
-
-            For more information on how to setup your bot with webhooks, see: ...
 
         .. important::
 

--- a/twitchio/ext/commands/context.py
+++ b/twitchio/ext/commands/context.py
@@ -520,8 +520,6 @@ class Context(Generic[BotT]):
             then additionally requires the ``user:bot`` scope on the bot,
             and either ``channel:bot`` scope from the broadcaster or moderator status.
 
-            See: ... for more information.
-
         Parameters
         ----------
         content: str
@@ -562,8 +560,6 @@ class Context(Generic[BotT]):
             then additionally requires the ``user:bot`` scope on the bot,
             and either ``channel:bot`` scope from the broadcaster or moderator status.
 
-            See: ... for more information.
-
         Parameters
         ----------
         content: str
@@ -602,7 +598,6 @@ class Context(Generic[BotT]):
         .. important::
 
             The broadcaster of the associated channel must have granted your bot the ``moderator:manage:announcements`` scope.
-            See: ... for more information.
 
         Parameters
         ----------
@@ -637,7 +632,6 @@ class Context(Generic[BotT]):
         .. important::
 
             The broadcaster of the associated channel must have granted your bot the ``moderator:manage:chat_messages`` scope.
-            See: ... for more information.
 
         .. note::
 
@@ -664,7 +658,6 @@ class Context(Generic[BotT]):
         .. important::
 
             The broadcaster of the associated channel must have granted your bot the ``moderator:manage:chat_messages`` scope.
-            See: ... for more information.
 
         Raises
         ------

--- a/twitchio/web/aio_adapter.py
+++ b/twitchio/web/aio_adapter.py
@@ -246,7 +246,7 @@ class AiohttpAdapter(BaseAdapter, web.Application):
             return web.Response(status=400)
 
         if not self._eventsub_secret:
-            msg: str = f"Eventsub Webhook '{self!r}' must be passed a secret. See: ... for more info.'"
+            msg: str = f"Eventsub Webhook '{self!r}' must be passed a secret.'"
             return web.Response(text=msg, status=400)
 
         msg_id: str | None = headers.get("Twitch-Eventsub-Message-Id", None)

--- a/twitchio/web/starlette_adapter.py
+++ b/twitchio/web/starlette_adapter.py
@@ -288,7 +288,7 @@ class StarletteAdapter(BaseAdapter, Starlette):
             return Response(status_code=400)
 
         if not self._eventsub_secret:
-            msg: str = f"Eventsub Webhook '{self!r}' must be passed a secret. See: ... for more info.'"
+            msg: str = f"Eventsub Webhook '{self!r}' must be passed a secret.'"
             return Response(msg, status_code=400)
 
         msg_id: str | None = headers.get("Twitch-Eventsub-Message-Id", None)


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

Add the `.respond` coroutine to a majority of `EventSub` models that support it, allowing the bot to send a message to the channel the event originated from.

Since it's virtually impossible for me to test each event directly, could someone please heavily scrutinize the changes to make sure no major breaking bugs will be introduced.

The changes have been tested on the `ChatMessage` payload.


- Added `AutomodMessageHold.respond`
- Added `AutomodSettingsUpdate.respond`
- Added `AutomodTermsUpdate.respond`
- Added `ChannelBitsUse.respond`
- Added `ChannelUpdate.respond`
- Added `ChannelFollow.respond`
- Added `ChannelAdBreakBegin.respond`
- Added `ChannelChatClear.respond`
- Added `ChannelChatClearUserMessages.respond`
- Added `ChatMessage.respond`
- Added `ChatNotification.respond`
- Added `ChatMessageDelete.respond`
- Added `ChatSettingsUpdate.respond`
- Added `SharedChatSessionBegin.respond`
- Added `SharedChatSessionUpdate.respond`
- Added `SharedChatSessionEnd.respond`
- Added `ChannelSubscribe.respond`
- Added `ChannelSubscriptionEnd.respond`
- Added `ChannelSubscriptionGift.respond`
- Added `ChannelSubscriptionMessage.respond`
- Added `ChannelCheer.respond`
- Added `ChannelBan.respond`
- Added `ChannelUnban.respond`
- Added `ChannelUnbanRequest.respond`
- Added `ChannelUnbanRequestResolve.respond`
- Added `ChannelModerate.respond`
- Added `ChannelModeratorAdd.respond`
- Added `ChannelModeratorRemove.respond`
- Added `ChannelPointsAutoRedeemAdd.respond`
- Added `ChannelPointsReward.respond`
- Added `ChannelPointsRedemptionAdd.respond`
- Added `ChannelPointsRedemptionUpdate.respond`
- Added `ChannelPollBegin.respond`
- Added `ChannelPollProgress.respond`
- Added `ChannelPollEnd.respond`
- Added `ChannelPredictionBegin.respond`
- Added `ChannelPredictionProgress.respond`
- Added `ChannelPredictionLock.respond`
- Added `ChannelPredictionEnd.respond`
- Added `SuspiciousUserUpdate.respond`
- Added `SuspiciousUserMessage.respond`
- Added `ChannelVIPAdd.respond`
- Added `ChannelVIPRemove.respond`
- Added `ChannelWarningAcknowledge.respond`
- Added `ChannelWarningSend.respond`
- Added `BaseCharityCampaign.respond`
- Added `CharityCampaignDonation.respond`
- Added `GoalBegin.respond`
- Added `GoalProgress.respond`
- Added `GoalEnd.respond`
- Added `HypeTrainBegin.respond`
- Added `HypeTrainProgress.respond`
- Added `HypeTrainEnd.respond`
- Added `ShieldModeBegin.respond`
- Added `ShieldModeEnd.respond`
- Added `ShoutoutCreate.respond`
- Added `ShoutoutReceive.respond`
- Added `StreamOnline.respond`
- Added `StreamOffline.respond`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
