### PR TITLE
Remove unnecessary token_for from ChannelPointsReward.fetch_reward

### DIFF
--- a/twitchio/models/eventsub_.py
+++ b/twitchio/models/eventsub_.py
@@ -3603,7 +3603,7 @@ class ChannelPointsReward(_ResponderEvent):
 
         return Asset(url, http=self._http)
 
-    async def fetch_reward(self, *, token_for: str) -> CustomReward:
+    async def fetch_reward(self) -> CustomReward:
         reward = await self.broadcaster.fetch_custom_rewards(ids=[self.id])
         return reward[0]
 


### PR DESCRIPTION
## Description

The `token_for` argument of `ChannelPointsReward.fetch_reward` is unnecessary and results in a `TypeError` when not provided. This PR removes the unnecessary and unused argument.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
