### PR TITLE
Feature/translations

### DIFF
--- a/docs/exts/commands/core.rst
+++ b/docs/exts/commands/core.rst
@@ -54,6 +54,8 @@ Decorators
 
 .. autofunction:: twitchio.ext.commands.cooldown(*, base: BaseCooldown, rate: int, per: float, key: Callable[[Any], Hashable] | Callable[[Any], Coroutine[Any, Any, Hashable]] | BucketType, **kwargs: ~typing.Any)
 
+.. autofunction:: twitchio.ext.commands.translator
+
 
 Guards
 ######
@@ -97,4 +99,11 @@ Converters
     :members:
 
 .. autoclass:: twitchio.ext.commands.ColourConverter()
+    :members:
+
+
+Translators
+###########
+
+.. autoclass:: twitchio.ext.commands.Translator()
     :members:

--- a/docs/exts/commands/exceptions.rst
+++ b/docs/exts/commands/exceptions.rst
@@ -57,6 +57,8 @@ Exceptions
 
 .. autoexception:: twitchio.ext.commands.NoEntryPointError
 
+.. autoexception:: twitchio.ext.commands.TranslatorError
+
 
 Exception Hierarchy
 ~~~~~~~~~~~~~~~~~~~
@@ -80,6 +82,7 @@ Exception Hierarchy
                 - :exc:`ExpectedClosingQuoteError`
         - :exc:`GuardFailure`
             - :exc:`CommandOnCooldown`
+        - :exc:`TranslatorError`
     - :exc:`ModuleError`
         - :exc:`ModuleLoadFailure`
         - :exc:`ModuleAlreadyLoadedError`

--- a/docs/getting-started/changelog.rst
+++ b/docs/getting-started/changelog.rst
@@ -96,7 +96,7 @@ Changelog
         - Added :meth:`twitchio.StreamOffline.respond`
     
     - Bug fixes
-        - Remove the unnecessary ``token_for`` parameter from :meth:`twitchio.eventsub.ChannelPointsReward.fetch_reward`. `#510 <https://github.com/PythonistaGuild/TwitchIO/pull/510>`_
+        - Remove the unnecessary ``token_for`` parameter from :meth:`twitchio.ChannelPointsReward.fetch_reward`. `#510 <https://github.com/PythonistaGuild/TwitchIO/pull/510>`_
 
 - twitchio.web.AiohttpAdapter
     - Bug fixes

--- a/docs/getting-started/changelog.rst
+++ b/docs/getting-started/changelog.rst
@@ -12,14 +12,26 @@ Changelog
 - twitchio
     - Additions
         - Added ``__hash__`` to :class:`twitchio.PartialUser` allowing it to be used as a key.
+        - Added the ``--create-new`` interactive script to ``__main__`` allowing boiler-plate to be generated for a new Bot.
 
     - Changes
         - Adjusted the Starlette logging warning wording.
+        - Delayed the Starlette logging warning and removed it from ``web/__init__.py``.
         - :class:`twitchio.PartialUser`, :class:`twitchio.User` and :class:`twitchio.Chatter` now have ``__hash__`` implementations derived from :class:`~twitchio.PartialUser`, which use the unique ID.
 
     - Bug fixes
         - :meth:`twitchio.Clip.fetch_video` now properly returns ``None`` when the :class:`twitchio.Clip` has no ``video_id``.
         - :class:`twitchio.ChatterColor` no longer errors whan no valid hex is provided by Twitch.
+        - Some general typing/spelling errors cleaned up in Documentation and Logging.
+        - Removed some redundant logging.
+
+- twitchio.AutoClient
+    - Additions
+        - Added ``force_subscribe`` keyword argument to :class:`twitchio.AutoClient`, allowing subscriptions passed to be made everytime the client is started.
+
+- twitchio.ext.commands.AutoBot
+    - Additions
+        - Added ``force_subscribe`` keyword argument to :class:`twitchio.ext.commands.AutoBot`, allowing subscriptions passed to be made everytime the bot is started. 
 
 - twitchio.eventsub
     - Additions
@@ -82,13 +94,35 @@ Changelog
         - Added :meth:`twitchio.ShoutoutReceive.respond`
         - Added :meth:`twitchio.StreamOnline.respond`
         - Added :meth:`twitchio.StreamOffline.respond`
+    
+    - Bug fixes
+        - Remove the unnecessary ``token_for`` parameter from :meth:`twitchio.eventsub.ChannelPointsReward.fetch_reward`. `#510 <https://github.com/PythonistaGuild/TwitchIO/pull/510>`_
+
+- twitchio.web.AiohttpAdapter
+    - Bug fixes
+        - Fixed the redirect URL not allowing HOST/PORT when a custom domain was passed.
+          - The redirect URL is now determined based on where the request came from.
+
+- twitchio.web.StarletteAdapter
+    - Bug fixes
+        - Fixed the redirect URL not allowing HOST/PORT when a custom domain was passed.
+          - The redirect URL is now determined based on where the request came from.
+        - Fixed Uvicorn hanging the process when attempting to close the :class:`asyncio.Loop` on **Windows**.
+          - After ``5 seconds`` Uvicorn will be forced closed if it cannot gracefully close in this time.
 
 - ext.commands
     - Additions
+        - Added :class:`~twitchio.ext.commands.Translator`
+        - Added :func:`~twitchio.ext.commands.translator`
+        - Added :attr:`twitchio.ext.commands.Command.translator`
+        - Added :meth:`twitchio.ext.commands.Context.send_translated`
+        - Added :meth:`twitchio.ext.commands.Context.reply_translated`
         - Added :class:`~twitchio.ext.commands.Converter`
         - Added :class:`~twitchio.ext.commands.UserConverter`
         - Added :class:`~twitchio.ext.commands.ColourConverter`
         - Added :class:`~twitchio.ext.commands.ColorConverter` alias.
+        - Added :attr:`twitchio.ext.commands.Command.signature` which is a POSIX-like signature for the command.
+        - Added :attr:`twitchio.ext.commands.Command.parameters` which is a mapping of parameter name to :class:`inspect.Parameter` associated with the command callback.
         - Added :attr:`twitchio.ext.commands.Command.help` which is the docstring of the command callback.
         - Added ``__doc__`` to :class:`~twitchio.ext.commands.Command` which takes from the callback ``__doc__``.
         - Added :meth:`twitchio.ext.commands.Command.run_guards`

--- a/twitchio/ext/commands/context.py
+++ b/twitchio/ext/commands/context.py
@@ -257,6 +257,15 @@ class Context(Generic[BotT]):
         return self._type
 
     @property
+    def translator(self) -> Translator[Any] | None:
+        """Property returning the :class:`.commands.Translator` assigned to the :class:`.commands.Command` if found or
+        ``None``. This property will always return ``None`` if no valid command or prefix is associated with this Context."""
+        if not self.command:
+            return None
+
+        return self.command.translator
+
+    @property
     def error_dispatched(self) -> bool:
         return self._error_dispatched
 
@@ -594,7 +603,7 @@ class Context(Generic[BotT]):
         TranslatorError
             An error occurred during translation.
         """
-        translator: Translator | None = getattr(self.command, "translator", None)
+        translator: Translator[Any] | None = self.translator
         new = (f"/me {content}" if me else content).strip()
 
         if not self.command or not translator:
@@ -722,7 +731,7 @@ class Context(Generic[BotT]):
         if self._type is ContextType.REWARD:
             raise TypeError("Cannot reply to a message in a Reward based context.")
 
-        translator: Translator | None = getattr(self.command, "translator", None)
+        translator: Translator[Any] | None = self.translator
         new = (f"/me {content}" if me else content).strip()
 
         if not self.command or not translator:

--- a/twitchio/ext/commands/context.py
+++ b/twitchio/ext/commands/context.py
@@ -545,6 +545,53 @@ class Context(Generic[BotT]):
         return await self.channel.send_message(sender=self.bot.bot_id, message=new)
 
     async def send_translated(self, content: str, *, me: bool = False, langcode: str | None = None) -> SentMessage:
+        """|coro|
+
+        Send a translated chat message to the channel associated with this context.
+
+        You must have added a :class:`.commands.Translator` to your :class:`.commands.Command` in order to effectively use
+        this method. If no :class:`.commands.Translator` is found, this method acts identical to :meth:`.send`.
+
+        If this method can not find a valid language code, E.g. both :meth:`.commands.Translator.get_langcode` and the parameter
+        ``langcode`` return ``None``, this method acts identical to :meth:`.send`.
+
+        See the following documentation for more details on translators:
+
+        - :class:`.commands.Translator`
+        - :class:`.commands.translator`
+
+        .. important::
+
+            You must have the ``user:write:chat`` scope. If an app access token is used,
+            then additionally requires the ``user:bot`` scope on the bot,
+            and either ``channel:bot`` scope from the broadcaster or moderator status.
+
+        Parameters
+        ----------
+        content: str
+            The content of the message you would like to translate and then send.
+            This **and** the translated version of this content cannot exceed ``500`` characters.
+            Additionally the content parameter will be stripped of all leading and trailing whitespace.
+        me: bool
+            An optional bool indicating whether you would like to send this message with the ``/me`` chat command.
+        langcode: str | None
+            An optional ``langcode`` to override the ``langcode`` returned from :meth:`.commands.Translator.get_langcode`.
+            This should only be provided if you do custom language code lookups outside of your
+            :class:`.commands.Translator`. Defaults to ``None``.
+
+
+        Returns
+        -------
+        SentMessage
+            The payload received by Twitch after sending this message.
+
+        Raises
+        ------
+        HTTPException
+            Twitch failed to process the message, could be ``400``, ``401``, ``403``, ``422`` or any ``5xx`` status code.
+        MessageRejectedError
+            Twitch rejected the message from various checks.
+        """
         translator: Translator | None = getattr(self.command, "translator", None)
         new = (f"/me {content}" if me else content).strip()
 

--- a/twitchio/ext/commands/context.py
+++ b/twitchio/ext/commands/context.py
@@ -558,7 +558,7 @@ class Context(Generic[BotT]):
         See the following documentation for more details on translators:
 
         - :class:`.commands.Translator`
-        - :class:`.commands.translator`
+        - :func:`.commands.translator`
 
         .. important::
 

--- a/twitchio/ext/commands/context.py
+++ b/twitchio/ext/commands/context.py
@@ -607,7 +607,7 @@ class Context(Generic[BotT]):
         except Exception as e:
             raise TranslatorError(f"An exception occurred fetching a language code for '{invoked}'.", original=e) from e
 
-        if not code:
+        if code is None:
             return await self.channel.send_message(sender=self.bot.bot_id, message=new)
 
         try:
@@ -735,7 +735,7 @@ class Context(Generic[BotT]):
         except Exception as e:
             raise TranslatorError(f"An exception occurred fetching a language code for '{invoked}'.", original=e) from e
 
-        if not code:
+        if code is None:
             return await self.channel.send_message(sender=self.bot.bot_id, message=new, reply_to_message_id=self._payload.id)
 
         try:

--- a/twitchio/ext/commands/core.py
+++ b/twitchio/ext/commands/core.py
@@ -225,11 +225,11 @@ class Command(Generic[Component_T, P]):
         self._before_hook: Callable[[Component_T, Context[Any]], Coro] | Callable[[Context[Any]], Coro] | None = None
         self._after_hook: Callable[[Component_T, Context[Any]], Coro] | Callable[[Context[Any]], Coro] | None = None
 
-        translator: Translator | type[Translator] | None = getattr(callback, "__command_translator__", None)
+        translator: Translator[Any] | type[Translator[Any]] | None = getattr(callback, "__command_translator__", None)
         if translator and inspect.isclass(translator):
             translator = translator()
 
-        self._translator: Translator | None = translator
+        self._translator: Translator[Any] | None = translator
 
         self._help: str = callback.__doc__ or ""
         self.__doc__ = self._help
@@ -271,7 +271,7 @@ class Command(Generic[Component_T, P]):
         self._signature = help_sig
 
     @property
-    def translator(self) -> Translator | None:
+    def translator(self) -> Translator[Any] | None:
         """Property returning the :class:`.commands.Translator` associated with this command or ``None`` if one was not
         used.
         """
@@ -1482,7 +1482,7 @@ class Group(Mixin[Component_T], Command[Component_T, P]):
         return wrapper
 
 
-def translator(cls: Translator | type[Translator]) -> Any:
+def translator(cls: Translator[Any] | type[Translator[Any]]) -> Any:
     """|deco|
 
     Decorator which adds a :class:`.commands.Translator` to a :class:`.commands.Command`.

--- a/twitchio/ext/commands/core.py
+++ b/twitchio/ext/commands/core.py
@@ -61,6 +61,7 @@ __all__ = (
     "is_staff",
     "is_vip",
     "reward_command",
+    "translator",
 )
 
 
@@ -68,6 +69,7 @@ if TYPE_CHECKING:
     from twitchio.user import Chatter
 
     from .context import Context
+    from .translators import Translator
     from .types_ import BotT
 
     P = ParamSpec("P")
@@ -223,6 +225,12 @@ class Command(Generic[Component_T, P]):
         self._before_hook: Callable[[Component_T, Context[Any]], Coro] | Callable[[Context[Any]], Coro] | None = None
         self._after_hook: Callable[[Component_T, Context[Any]], Coro] | Callable[[Context[Any]], Coro] | None = None
 
+        translator: Translator | type[Translator] | None = getattr(callback, "__command_translator__", None)
+        if translator and inspect.isclass(translator):
+            translator = translator()
+
+        self._translator: Translator | None = translator
+
         self._help: str = callback.__doc__ or ""
         self.__doc__ = self._help
 
@@ -261,6 +269,10 @@ class Command(Generic[Component_T, P]):
             help_sig += f" {s}"
 
         self._signature = help_sig
+
+    @property
+    def translator(self) -> Translator | None:
+        return self._translator
 
     @property
     def parameters(self) -> MappingProxyType[str, inspect.Parameter]:
@@ -1465,6 +1477,20 @@ class Group(Mixin[Component_T], Command[Component_T, P]):
             return new
 
         return wrapper
+
+
+def translator(cls: Translator | type[Translator]) -> Any:
+    def wrapper(func: Any) -> Any:
+        inst = cls() if inspect.isclass(cls) else cls
+
+        if isinstance(func, Command):
+            func._translator = inst
+        else:
+            func.__command_translator = inst
+
+        return func  # type: ignore
+
+    return wrapper
 
 
 def guard(predicate: Callable[..., bool] | Callable[..., CoroC]) -> Any:

--- a/twitchio/ext/commands/core.py
+++ b/twitchio/ext/commands/core.py
@@ -272,6 +272,9 @@ class Command(Generic[Component_T, P]):
 
     @property
     def translator(self) -> Translator | None:
+        """Property returning the :class:`.commands.Translator` associated with this command or ``None`` if one was not
+        used.
+        """
         return self._translator
 
     @property
@@ -1480,6 +1483,19 @@ class Group(Mixin[Component_T], Command[Component_T, P]):
 
 
 def translator(cls: Translator | type[Translator]) -> Any:
+    """|deco|
+
+    Decorator which adds a :class:`.commands.Translator` to a :class:`.commands.Command`.
+
+    You can provide the class or instance of your implemented :class:`.commands.Translator` to this decorator.
+
+    See the :class:`.commands.Translator` documentation for more information on translators.
+
+    .. note::
+
+        You can only have one :class:`.commands.Translator` per command.
+    """
+
     def wrapper(func: Any) -> Any:
         inst = cls() if inspect.isclass(cls) else cls
 

--- a/twitchio/ext/commands/exceptions.py
+++ b/twitchio/ext/commands/exceptions.py
@@ -214,7 +214,7 @@ class TranslatorError(CommandError):
     Attributes
     ----------
     original: :class:`Exception` | None
-        The original exception that caused this error. Could be None.
+        The original exception that caused this error. Could be ``None``.
     """
 
     def __init__(self, msg: str | None = None, original: Exception | None = None) -> None:

--- a/twitchio/ext/commands/exceptions.py
+++ b/twitchio/ext/commands/exceptions.py
@@ -51,6 +51,7 @@ __all__ = (
     "ModuleNotLoadedError",
     "NoEntryPointError",
     "PrefixError",
+    "TranslatorError",
     "UnexpectedQuoteError",
 )
 
@@ -72,7 +73,7 @@ class CommandInvokeError(CommandError):
     Attributes
     ----------
     original: :class:`Exception` | None
-        The original exception that caused this error. Could be None.
+        The original exception that caused this error. Could be ``None``.
     """
 
     def __init__(self, msg: str | None = None, original: Exception | None = None) -> None:
@@ -204,3 +205,18 @@ class CommandOnCooldown(GuardFailure):
         self.cooldown: BaseCooldown = cooldown
         self.remaining: float = remaining
         super().__init__(msg or f"Cooldown is ratelimited. Try again in {remaining} seconds.")
+
+
+class TranslatorError(CommandError):
+    """Exception raised when a :class:`.commands.Translator` raises an error while attempting to get a language code
+    or translate content provided to :meth:`~.commands.Context.send_translated`.
+
+    Attributes
+    ----------
+    original: :class:`Exception` | None
+        The original exception that caused this error. Could be None.
+    """
+
+    def __init__(self, msg: str | None = None, original: Exception | None = None) -> None:
+        self.original: Exception | None = original
+        super().__init__(msg)

--- a/twitchio/ext/commands/translators.py
+++ b/twitchio/ext/commands/translators.py
@@ -41,7 +41,7 @@ class Translator(abc.ABC):
     This class allows you to implement logic to translate messages sent via the :meth:`.commands.Context.send_translated`
     method in commands or anywhere :class:`.commands.Context` is available.
 
-    You should pass your implemented class to the :meth:`.commands.translator` decorator on top of a :class:`~.commands.Command`.
+    You should pass your implemented class to the :func:`.commands.translator` decorator on top of a :class:`~.commands.Command`.
 
     .. important::
 

--- a/twitchio/ext/commands/translators.py
+++ b/twitchio/ext/commands/translators.py
@@ -22,11 +22,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from .bot import AutoBot as AutoBot, Bot as Bot
-from .components import *
-from .context import *
-from .converters import *
-from .cooldowns import *
-from .core import *
-from .exceptions import *
-from .translators import *
+from __future__ import annotations
+
+import abc
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    from .context import Context
+
+
+__all__ = ("Translator",)
+
+
+class Translator(abc.ABC):
+    @abc.abstractmethod
+    def get_langcode(self, ctx: Context[Any], name: str) -> str | None: ...
+
+    @abc.abstractmethod
+    async def translate(self, ctx: Context[Any], text: str, langcode: str) -> str: ...

--- a/twitchio/ext/commands/translators.py
+++ b/twitchio/ext/commands/translators.py
@@ -25,17 +25,20 @@ SOFTWARE.
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 
 if TYPE_CHECKING:
     from .context import Context
 
 
+T = TypeVar("T")
+
+
 __all__ = ("Translator",)
 
 
-class Translator(abc.ABC):
+class Translator(Generic[T], abc.ABC):
     """Abstract Base Class for command translators.
 
     This class allows you to implement logic to translate messages sent via the :meth:`.commands.Context.send_translated`
@@ -49,16 +52,16 @@ class Translator(abc.ABC):
     """
 
     @abc.abstractmethod
-    def get_langcode(self, ctx: Context[Any], name: str) -> str | None:
+    def get_langcode(self, ctx: Context[Any], name: str) -> T | None:
         """Method which is called when :meth:`.commands.Context.send_translated` is used on a :class:`.commands.Command`
         which has an associated Translator, to determine the ``langcode`` which should be passed to :meth:`.translate` or ``None``
         if the content should not be translated.
 
-        By default the ``name`` or ``alias`` used to invoke the command is passed alongside :class:`.commands.Context` to aid in
-        determining the ``langcode`` you should use.
+        By default the lowercase ``name`` or ``alias`` used to invoke the command is passed alongside :class:`.commands.Context`
+        to aid in determining the ``langcode`` you should use.
 
-        You can use any system for the language codes, however they must be a :class:`str`. We also recommend using a
-        recognized system such as the ``ISO 639`` language code format.
+        You can use any format or type for the language codes. We recommend using a recognized system such as the ``ISO 639``
+        language code format as a :class:`str`.
 
         Parameters
         ----------
@@ -70,8 +73,10 @@ class Translator(abc.ABC):
 
         Returns
         -------
-        str
-            The language code as a :class:`str` to pass to :meth:`.translate`.
+        Any
+            The language code to pass to :meth:`.translate`.
+        None
+            No translation attempt should be made with :meth:`.translate`.
 
         Example
         -------
@@ -81,7 +86,7 @@ class Translator(abc.ABC):
             # For example purposes only the "get_langcode" method is shown in this example...
             # The "translate" method must also be implemented...
 
-            class HelloTranslator(commands.Translator):
+            class HelloTranslator(commands.Translator[str]):
                 def __init__(self) -> None:
                     self.code_mapping = {"hello": "en", "bonjour": "fr"}
 
@@ -98,7 +103,7 @@ class Translator(abc.ABC):
         """
 
     @abc.abstractmethod
-    async def translate(self, ctx: Context[Any], text: str, langcode: str) -> str:
+    async def translate(self, ctx: Context[Any], text: str, langcode: T) -> str:
         """|coro|
 
         Method used to translate the content passed to :meth:`.commands.Context.send_translated` with the language code returned from
@@ -116,7 +121,7 @@ class Translator(abc.ABC):
             The context surrounding the command invocation.
         text: str
             The content passed to :meth:`~.commands.Context.send_translated` which should be translated.
-        langcode: str
+        langcode: Any
             The language code returned via :meth:`.get_langcode`, which can be used to determine the language the text should
             be translated to.
 
@@ -133,7 +138,7 @@ class Translator(abc.ABC):
             # For example purposes only the "translate" method is shown in this example...
             # The "get_langcode" method must also be implemented...
 
-            class HelloTranslator(commands.Translator):
+            class HelloTranslator(commands.Translator[str]):
 
                 async def translate(self, ctx: commands.Context, text: str, langcode: str) -> str:
                     # Usually you would call an API, or retrieve from a database or dict or some other solution...

--- a/twitchio/ext/commands/translators.py
+++ b/twitchio/ext/commands/translators.py
@@ -77,6 +77,7 @@ class Translator(abc.ABC):
         -------
 
         .. code:: python3
+
             # For example purposes only the "get_langcode" method is shown in this example...
             # The "translate" method must also be implemented...
 
@@ -128,6 +129,7 @@ class Translator(abc.ABC):
         -------
 
         .. code:: python3
+
             # For example purposes only the "translate" method is shown in this example...
             # The "get_langcode" method must also be implemented...
 


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

Adds an interface to translate content sent from `Context` in a `Command`.

The ABC `commands.Translator` can be implemented and added to a command by users to translate content sent via `Context.send_translated`.

**Example:**

```py
class HelloTranslator(commands.Translator):
    def __init__(self) -> None:
        self.translations = {"fr": {"Hello World!": "Bonjour le monde!"}}

    def get_langcode(self, ctx: commands.Context, name: str) -> str | None:
        if name == "bonjour":
            return "fr"

    async def translate(self, ctx: commands.Context, text: str, langcode: str) -> str:
        # Ideally you store translations in another medium or call an API etc...
        translations = self.translations.get(langcode, {})
        translation = translations.get(text, text)
        
        return translation


@commands.command(aliases=["bonjour"])
@commands.translator(HelloTranslator)
async def hello(ctx: commands.Context) -> None:
    await ctx.send_translated("Hello World!")
```


Added:
- `commands.Translator`
- `commands.translator`
- `Context.send_translated`
- `commands.TranslatorError`
- `commands.Command.translator`

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
