### PR TITLE
docs: remove token_for from PartialUser.fetch_moderators parameters

### DIFF
--- a/twitchio/user.py
+++ b/twitchio/user.py
@@ -2383,10 +2383,6 @@ class PartialUser:
         user_ids: list[str | int] | None
             A list of user IDs used to filter the results. To specify more than one ID, include this parameter for each moderator you want to get.
             The returned list includes only the users from the list who are moderators in the broadcaster's channel. You may specify a maximum of 100 IDs.
-        token_for: str | PartialUser
-            User access token that includes the ``moderation:read`` scope.
-            If your app also adds and removes moderators, you can use the ``channel:manage:moderators`` scope instead.
-            The user ID in the access token must match the broadcaster's ID.
         first: int
             The maximum number of items to return per page in the response. The minimum page size is 1 item per page and the maximum is 100 items per page. The default is 20.
         max_results: int | None


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->
just a minor documentation fixup-- `token_for` is documented in the parameter list, but is not a supported keyword argument for `PartialUser.fetch_moderators()`. rather, it's (helpfully) pulled directly from the object internal to the method

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
