### PR TITLE
docs: fix typo in commands example

### DIFF
--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -155,7 +155,7 @@ Before running the code below, there are just a couple more steps we need to tak
 
         @commands.command()
         async def hi(self, ctx: commands.Context) -> None:
-            """Command that replys to the invoker with Hi <name>!
+            """Command that replies to the invoker with Hi <name>!
 
             !hi
             """

--- a/examples/basic_bot/main.py
+++ b/examples/basic_bot/main.py
@@ -57,7 +57,7 @@ class Bot(commands.Bot):
 class GeneralCommands(commands.Component):
     @commands.command()
     async def hi(self, ctx: commands.Context[Bot]) -> None:
-        """Command that replys to the invoker with Hi <name>!
+        """Command that replies to the invoker with Hi <name>!
 
         !hi
         """


### PR DESCRIPTION
## Description

This PR fixes a typo in the `hi` command example.
Corrected `replys` → `replies` in the `hi` command docstring and corresponding docs.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x ] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
